### PR TITLE
Important config fix and commenting

### DIFF
--- a/internel/config.go
+++ b/internel/config.go
@@ -1,12 +1,14 @@
 package internel
 
 import (
-	"github.com/go-yaml/yaml"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/go-yaml/yaml"
 )
 
+// Config structure
 type Config struct {
 	Token  string   `yaml:"token"`
 	Prefix string   `yaml:"prefix"`
@@ -15,6 +17,7 @@ type Config struct {
 	Guild  string   `yaml:"guild"`
 }
 
+// GetConfig retrieves config as Config from path
 func GetConfig(path string) (config Config) {
 	if _, err := os.Stat(path); err != nil {
 		genConfig(path)
@@ -27,7 +30,7 @@ func GetConfig(path string) (config Config) {
 		log.Fatalln("Failed to read from configuration file. " + err.Error())
 	}
 
-	if err = yaml.Unmarshal(data, config); err != nil {
+	if err = yaml.Unmarshal(data, &config); err != nil {
 		log.Fatalln("Failed to parse configuration file. " + err.Error())
 	}
 

--- a/internel/server.go
+++ b/internel/server.go
@@ -2,22 +2,27 @@ package internel
 
 import (
 	"fmt"
-	dg "github.com/bwmarrin/discordgo"
 	"log"
+
+	dg "github.com/bwmarrin/discordgo"
 )
 
+// AuthArgs structure
 type AuthArgs struct{ MemberID string }
 
+// AuthResponse structure
 type AuthResponse struct {
 	Role    string
 	IsAdmin bool
 }
 
+// AuthServer structure
 type AuthServer struct {
 	config *Config
 	client *dg.Session
 }
 
+// Auth function authentication framework
 func (a *AuthServer) Auth(args *AuthArgs, reply *AuthResponse) error {
 	member, err := a.client.GuildMember(a.config.Guild, args.MemberID)
 	isAdmin := false


### PR DESCRIPTION
Commenting makes it easier to work for people on vscode since uncommented structures and exported functions return warnings.